### PR TITLE
fix mapper number detection

### DIFF
--- a/src/nes.rs
+++ b/src/nes.rs
@@ -96,7 +96,7 @@ pub fn read_ines(filename: String) -> Result<Ines, io::Error> {
         has_four_screen_vram: get_bit(header[6], 3) > 0,
         is_playchoice10: false, // TODO
         is_vs_unisystem: false, // TODO
-        mapper: (header[6] >> 4) + (header[7] >> 4) << 4,
+        mapper: (header[6] >> 4) + ((header[7] >> 4) << 4),
         prg_rom: HiddenBytes(prg_rom),
         chr_rom: HiddenBytes(chr_rom),
     };


### PR DESCRIPTION
per header https://wiki.nesdev.com/w/index.php/INES , calculation should shift header 7 nibble and then add header 6 nibble. 
An example is the Zelda rom, it uses mapper 1, but the code as written detects it as mapper 16 because it is adding 0 to 1 and shifting the result by 4, instead of shifting 0 by 4 and adding it to 1.